### PR TITLE
Fix Windows storage (#6)

### DIFF
--- a/lib/local-history-view.js
+++ b/lib/local-history-view.js
@@ -182,9 +182,14 @@ LocalHistoryView.prototype.saveRevision = function saveRevision(buffer) {
 
   var now  = new Date();
 
+  var pathDirName = path.dirname(buffer.file.path);
+  if (process.platform === 'win32') {
+      pathDirName = pathDirName.replace(/:/g,'');
+  }
+
   var file = path.join(
     localHistoryPath,
-    path.dirname(buffer.file.path),
+    pathDirName,
 
     // YYYY-mm-dd.HH.ii.ss.basename
     now.toISOString().replace(/^(\d{4}\-\d{2}\-\d{2}).(\d{2})\:(\d{2})\:(\d{2}).*$/,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,10 +23,15 @@ module.exports.getFileRevisionList = function getFileRevisionList(filePath) {
   var files        = [];
   var fileBaseName = path.basename(filePath);
 
+  var pathDirName = path.dirname(filePath);
+  if (process.platform === 'win32') {
+      pathDirName = pathDirName.replace(/:/g,'');
+  }
+
   // list the directory (recursively) of the file
   var list         = fs.listTreeSync(path.join(
     this.getLocalHistoryPath(),
-    path.dirname(filePath)
+    pathDirName
   ));
 
   for(var i in list) {


### PR DESCRIPTION
Use cases tested on windows:
- Create new local history entry
- List local history
- Diff local history with windows meld installed and in system path.
