### PR TITLE
Fix exception when launching DiffTool

### DIFF
--- a/lib/local-history-view.js
+++ b/lib/local-history-view.js
@@ -144,7 +144,7 @@ LocalHistoryView.prototype.openDifftoolForCurrentFile = function openDifftoolFor
 };
 
 LocalHistoryView.prototype.openDifftool = function openDifftool(current, revision) {
-  var basePath = atom.project.getPath();
+  var basePath = atom.project.getPaths()[0];
   var diffCmd  = atom.config.get('local-history.difftoolCommand');
 
   if (diffCmd && basePath && current && revision) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ module.exports.getFileDate = function getFileDate(filePath) {
 
 module.exports.getOriginBaseName = function getOriginBaseName(filePath) {
   var basePath = path.basename(filePath);
-  return basePath.substr(basePath.lastIndexOf('_') + 1);
+  return basePath.substr(basePath.split('_', 2).join('_').length + 1);
 };
 
 module.exports.getFileRevisionList = function getFileRevisionList(filePath) {


### PR DESCRIPTION
atom.project.getPath() was removed in favor of atom.project.getPaths() in Atom >= v206