### PR TITLE
adding possibility to open diff in internal atom tools

### DIFF
--- a/lib/local-history-view.js
+++ b/lib/local-history-view.js
@@ -153,6 +153,11 @@ LocalHistoryView.prototype.openDifftool = function openDifftool(current, revisio
       .replace(/\{revision-file\}/g, revision)
     ;
 
+    // If command starts with protocol (eg compare-files:), then we try to open it with atom
+    if (diffCmd.match(/^([a-zA-Z0-9\-]+:)/)) {
+        return atom.workspace.open(diffCmd, { searchAllPanes : true });
+    }
+
     return exec('cd ' + basePath + ' && ' + diffCmd, function (err) {
       var messages;
 


### PR DESCRIPTION
Adding possibility to use protocol: in difftool command settings to make it possible to open diff directly in Atom