### PR TITLE
Standardise the date format for history file names.

### DIFF
--- a/lib/local-history-view.js
+++ b/lib/local-history-view.js
@@ -195,6 +195,9 @@ LocalHistoryView.prototype.saveRevision = function saveRevision(buffer) {
   now         = new Date();
   day         = '' + now.getDate();
   month       = '' + (now.getMonth() + 1);
+  hour        = '' + now.getHours(); //24-hours format
+  minute      = '' + now.getMinutes();
+  second      = '' + now.getSeconds();
   pathDirName = path.dirname(buffer.file.path);
 
   if (day.length === 1) {
@@ -205,11 +208,25 @@ LocalHistoryView.prototype.saveRevision = function saveRevision(buffer) {
     month = '0' + month;
   }
 
+  if (hour.length === 1) {
+    hour = '0' + hour;
+  }
+
+  if (minute.length === 1) {
+    minute = '0' + minute;
+  }
+
+  if (second.length === 1) {
+    second = '0' + second;
+  }
+
   // YYYY-mm-dd_HH-ii-ss_basename
   revFileName  = now.getFullYear() +
     '-' + month +
     '-' + day +
-    '_' + now.toLocaleTimeString().replace(/:/g, '-') +
+    '_' + hour +
+    '-' + minute +
+    '-' + second +
     '_' + path.basename(buffer.file.path)
   ;
 


### PR DESCRIPTION
Using `now.toLocaleTimeString().replace(/:/g, '-')` on my machine produces file names like `2016-07-15_1-23-14 PM_example.txt` which isn't sort friendly when doing `ls -la`.
I've now changed it so that the file names are always uniform and sortable irrespective of system's locale settings (now `2016-07-15_13-26-45_example.txt`).
Purging still works as expected because it only reads first 10 characters of the file which are still same.