### PR TITLE
Context menu only for files

### DIFF
--- a/menus/local-history.cson
+++ b/menus/local-history.cson
@@ -1,6 +1,6 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  'atom-workspace':
+  'atom-text-editor':
     [
       {
         'label': 'Show history of current file',


### PR DESCRIPTION
The context menu could be used anywhere, not only for "historable" files and it is not necessary to show menu items of `local-history` everywhere. For example "Show history of current file" is useless in the context menu for the toolbar. So this PR fix it -> it will show menu items only for workspace context menu.
![2016-11-25_20-58-17](https://cloud.githubusercontent.com/assets/778908/20634564/c4baad58-b352-11e6-9dd4-ee176d1a20ee.png)
